### PR TITLE
Run vanilla-test.yml always

### DIFF
--- a/.github/workflows/vanilla-test.yml
+++ b/.github/workflows/vanilla-test.yml
@@ -4,13 +4,7 @@ on:
   push:
     branches:
       - master
-    paths:
-      - Project.toml
-      - test/environments/main/Project.toml
   pull_request:
-    paths:
-      - Project.toml
-      - test/environments/main/Project.toml
 
 jobs:
   vanilla-test:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -11,6 +11,7 @@ pull_request_rules:
       - status-success=Test Julia ~1.5.0-rc1
       - status-success=Test Julia 1.4
       - status-success=Documenter
+      - status-success=vanilla-test
       - label=ready-to-merge:squash
       - label!=work-in-progress
     actions:
@@ -23,6 +24,7 @@ pull_request_rules:
       - status-success=Test Julia ~1.5.0-rc1
       - status-success=Test Julia 1.4
       - status-success=Documenter
+      - status-success=vanilla-test
       - label=ready-to-merge:rebase
       - label!=work-in-progress
     actions:
@@ -35,6 +37,7 @@ pull_request_rules:
       - status-success=Test Julia ~1.5.0-rc1
       - status-success=Test Julia 1.4
       - status-success=Documenter
+      - status-success=vanilla-test
       - label=ready-to-merge:merge
       - label!=work-in-progress
     actions:
@@ -47,6 +50,7 @@ pull_request_rules:
       - status-success=Test Julia ~1.5.0-rc1
       - status-success=Test Julia 1.4
       - status-success=Documenter
+      - status-success=vanilla-test
       - label~=ready-to-merge:.*
     actions:
       review: {}


### PR DESCRIPTION
As the main CI is run with somewhat-old dependencies recorded in
`test/environments/main/Manifest.toml`, it is also nice to run the
test with the latest packages as would be installed via Pkg.
